### PR TITLE
[pipelines] Disable `correctPrincipalPoint` in templates

### DIFF
--- a/meshroom/pipelines/cameraTracking.mg
+++ b/meshroom/pipelines/cameraTracking.mg
@@ -153,8 +153,7 @@
             ],
             "inputs": {
                 "input": "{StructureFromMotion_1.output}",
-                "exportUndistortedImages": true,
-                "correctPrincipalPoint": true
+                "exportUndistortedImages": true
             },
             "internalInputs": {
                 "color": "#80766f"

--- a/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/cameraTrackingWithoutCalibration.mg
@@ -108,8 +108,7 @@
             ],
             "inputs": {
                 "input": "{StructureFromMotion_1.output}",
-                "exportUndistortedImages": true,
-                "correctPrincipalPoint": true
+                "exportUndistortedImages": true
             },
             "internalInputs": {
                 "color": "#80766f"

--- a/meshroom/pipelines/nodalCameraTracking.mg
+++ b/meshroom/pipelines/nodalCameraTracking.mg
@@ -114,8 +114,7 @@
             ],
             "inputs": {
                 "input": "{NodalSfM_1.output}",
-                "exportUndistortedImages": true,
-                "correctPrincipalPoint": true
+                "exportUndistortedImages": true
             },
             "internalInputs": {
                 "color": "#80766f"

--- a/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
+++ b/meshroom/pipelines/nodalCameraTrackingWithoutCalibration.mg
@@ -55,8 +55,7 @@
             ],
             "inputs": {
                 "input": "{NodalSfM_1.output}",
-                "exportUndistortedImages": true,
-                "correctPrincipalPoint": true
+                "exportUndistortedImages": true
             },
             "internalInputs": {
                 "color": "#80766f"

--- a/meshroom/pipelines/photogrammetryAndCameraTracking.mg
+++ b/meshroom/pipelines/photogrammetryAndCameraTracking.mg
@@ -164,8 +164,7 @@
             "inputs": {
                 "input": "{StructureFromMotion_1.output}",
                 "sfmDataFilter": "{ImageMatchingMultiSfM_2.inputB}",
-                "exportUndistortedImages": true,
-                "correctPrincipalPoint": true
+                "exportUndistortedImages": true
             },
             "internalInputs": {
                 "color": "#80766f"


### PR DESCRIPTION
This PR disables the correction of the principal point for all the `ExportAnimatedCamera` nodes in the templates.