### PR TITLE
bugfix PAR read/write

### DIFF
--- a/meshroom/nodes/imageSegmentation/ImageSegmentationPrompt.py
+++ b/meshroom/nodes/imageSegmentation/ImageSegmentationPrompt.py
@@ -206,7 +206,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%
 
             for k, (iFile, oFile) in enumerate(outFiles.items()):
                 if k >= chunk.range.start and k <= chunk.range.last:
-                    img, PAR = image.loadImage(iFile, True)
+                    img, h_ori, w_ori, PAR = image.loadImage(iFile, True)
                     mask, bboxes, tags = processor.process(image = img,
                                                            prompt = chunk.node.prompt.value,
                                                            synonyms = chunk.node.synonyms.value,
@@ -220,13 +220,13 @@ Bounded box sizes can be increased by a ratio from 0 to 100%
                     chunk.logger.debug('tags: {}'.format(tags))
                     chunk.logger.debug('bboxes: {}'.format(bboxes))
 
-                    image.writeImage(oFile[0], mask, PAR)
+                    image.writeImage(oFile[0], mask, h_ori, w_ori, PAR)
 
                     if (chunk.node.outputBboxImage.value):
                         imgBoxes = (img * 255.0).astype('uint8')
                         for bbox in bboxes:
                             imgBoxes = image.addRectangle(imgBoxes, bbox)
-                        image.writeImage(oFile[1], imgBoxes, PAR)
+                        image.writeImage(oFile[1], imgBoxes, h_ori, w_ori, PAR)
 
             del processor
             torch.cuda.empty_cache()


### PR DESCRIPTION
Mask image size is now always the same as source image size.
The source image height and width are used to drive the resize in the write function instead of pixel aspect ratio avoiding multiplication by a float and rounding.