### PR TITLE
`requirements.txt`: Fix install link for recognize-anything

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-ram @ https://github.com/xinyu1205/recognize-anything.git
+ram @ git+https://github.com/xinyu1205/recognize-anything.git
 groundingdino-py==0.4.0
 segment-anything==1.0


### PR DESCRIPTION
Installing a project from VCS with pip requires to use the specific "git+" syntax before providing the URL: https://pip.pypa.io/en/stable/cli/pip_install/#examples.