### PR TITLE
[nodes] Fix attributes in nodes' descriptions

### DIFF
--- a/meshroom/nodes/imageSegmentation/ImageDetectionPrompt.py
+++ b/meshroom/nodes/imageSegmentation/ImageDetectionPrompt.py
@@ -132,6 +132,7 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             description="Generated images with bounded boxes baked in.",
             semantic="image",
             value=lambda attr: desc.Node.internalFolder + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extension.value,
+            enabled=lambda node: node.outputBboxImage.value,
             group="",
         ),
     ]

--- a/meshroom/nodes/imageSegmentation/ImageSegmentationPrompt.py
+++ b/meshroom/nodes/imageSegmentation/ImageSegmentationPrompt.py
@@ -146,6 +146,15 @@ Bounded box sizes can be increased by a ratio from 0 to 100%.
             value=lambda attr: desc.Node.internalFolder + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extension.value,
             group="",
         ),
+        desc.File(
+            name="bboxes",
+            label="BBoxes",
+            description="Generated images with bounded boxes baked in.",
+            semantic="image",
+            value=lambda attr: desc.Node.internalFolder + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "_bboxes.jpg",
+            enabled=lambda node: node.outputBboxImage.value,
+            group="",
+        ),
     ]
 
     def resolvedPaths(self, inputSfm, outDir, keepFilename, ext):


### PR DESCRIPTION
This PR addresses the following issues:

1. In `ImageDetectionPrompt`, images with the bounding boxes can be generated if a specific option is selected. By default, it is not, but a dedicated image output was enabled for these specific images. This means that even if the option was not selected and no image was generated, the node remained clickable to load its (in this case, non-existent) output images.
2. In `ImageSegmentationPrompt`, the option to generate the images with the bounded box existed but there was no way to visualize them as ouputs.