### PR TITLE
BiRefNet matting node

### DIFF
--- a/meshroom/nodes/imageSegmentation/ImageBiRefNetMatting.py
+++ b/meshroom/nodes/imageSegmentation/ImageBiRefNetMatting.py
@@ -83,14 +83,14 @@ Based on the BiRefNet model.
             name="output",
             label="Masks Folder",
             description="Output path for the masks.",
-            value=desc.Node.internalFolder,
+            value="{nodeCacheFolder}",
         ),
         desc.File(
             name="masks",
             label="Masks",
             description="Generated segmentation masks.",
             semantic="image",
-            value=lambda attr: desc.Node.internalFolder + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extension.value,
+            value=lambda attr: "{nodeCacheFolder}/" + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extension.value,
             group="",
         ),
     ]

--- a/meshroom/nodes/imageSegmentation/ImageBiRefNetMatting.py
+++ b/meshroom/nodes/imageSegmentation/ImageBiRefNetMatting.py
@@ -95,7 +95,7 @@ Based on the BiRefNet model.
         ),
     ]
 
-    def resolvedPaths(self, inputSfm, outDir, keepFilename):
+    def resolvedPaths(self, inputSfm, outDir, keepFilename, extension):
         import pyalicevision as av
         from pathlib import Path
 
@@ -106,11 +106,11 @@ Based on the BiRefNet model.
             for id, v in views.items():
                 inputFile = v.getImage().getImagePath()
                 if keepFilename:
-                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + ".exr")
+                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extension)
                     outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
                 else:
                     outputFileMask = os.path.join(outDir, str(id) + ".exr")
-                    outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".exr")
+                    outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + "." + extension)
                 paths[inputFile] = (outputFileMask, outputFileBoxes)
 
         return paths
@@ -136,7 +136,7 @@ Based on the BiRefNet model.
 
             chunk.logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
 
-            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value)
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extension.value)
 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)

--- a/meshroom/nodes/imageSegmentation/ImageBiRefNetMatting.py
+++ b/meshroom/nodes/imageSegmentation/ImageBiRefNetMatting.py
@@ -141,8 +141,6 @@ Based on the BiRefNet model.
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)
 
-            # processor = segmentation.BiRefNetSeg(PATH_TO_WEIGHT = chunk.node.segmentationModelPath.value,
-            #                                      useGPU = chunk.node.useGpu.value)
             processor = segmentation.BiRefNetSeg(modelType = chunk.node.birefnetModelType.value,
                                                  useGPU = chunk.node.useGpu.value)
             bboxDict = {}

--- a/meshroom/nodes/imageSegmentation/ImageBiRefNetSegBox.py
+++ b/meshroom/nodes/imageSegmentation/ImageBiRefNetSegBox.py
@@ -1,0 +1,177 @@
+__version__ = "0.1"
+
+import os
+
+from meshroom.core import desc
+from meshroom.core.utils import VERBOSE_LEVEL
+
+
+class ImageBiRefNetSegBox(desc.Node):
+    size = desc.DynamicNodeSize("input")
+    gpu = desc.Level.INTENSIVE
+    parallelization = desc.Parallelization(blockSize=50)
+
+    category = "Utils"
+    documentation = """
+Generate a binary mask from an input bounded box and points.
+Based on the BiRefNet model.
+"""
+
+    inputs = [
+        desc.File(
+            name="input",
+            label="Input",
+            description="SfMData file input.",
+            value="",
+        ),
+        desc.File(
+            name="bboxFolder",
+            label="BBoxes Folder",
+            description="JSON file containing prompting bounded boxes.",
+            value="",
+        ),
+        desc.File(
+            name="segmentationModelPath",
+            label="Segmentation Model",
+            description="Weights file for the segmentation model.",
+            value='/s/apps/users/multiview/birefnet/develop/weights/BiRefNet-matting-epoch_100.pth',#os.getenv("RDS_SEGMENTATION_MODEL_PATH", ""),
+        ),
+        desc.BoolParam(
+            name="maskInvert",
+            label="Invert Masks",
+            description="Invert mask values. If selected, the pixels corresponding to the mask will be set to 0 instead of 255.",
+            value=False,
+        ),
+        desc.BoolParam(
+            name="useGpu",
+            label="Use GPU",
+            description="Use GPU for computation if available.",
+            value=True,
+            invalidate=False,
+        ),
+        desc.BoolParam(
+            name="keepFilename",
+            label="Keep Filename",
+            description="Keep the filename of the inputs for the outputs.",
+            value=False,
+        ),
+        desc.ChoiceParam(
+            name="extension",
+            label="Output File Extension",
+            description="Output image file extension.\n"
+                        "If unset, the output file extension will match the input's if possible.",
+            value="exr",
+            values=["exr", "png", "jpg"],
+            exclusive=True,
+            group="",  # remove from command line params
+        ),
+        desc.ChoiceParam(
+            name="verboseLevel",
+            label="Verbose Level",
+            description="Verbosity level (fatal, error, warning, info, debug).",
+            value="info",
+            values=VERBOSE_LEVEL,
+            exclusive=True,
+        ),
+    ]
+
+    outputs = [
+        desc.File(
+            name="output",
+            label="Masks Folder",
+            description="Output path for the masks.",
+            value=desc.Node.internalFolder,
+        ),
+        desc.File(
+            name="masks",
+            label="Masks",
+            description="Generated segmentation masks.",
+            semantic="image",
+            value=lambda attr: desc.Node.internalFolder + ("<FILESTEM>" if attr.node.keepFilename.value else "<VIEW_ID>") + "." + attr.node.extension.value,
+            group="",
+        ),
+    ]
+
+    def resolvedPaths(self, inputSfm, outDir, keepFilename):
+        import pyalicevision as av
+        from pathlib import Path
+
+        paths = {}
+        dataAV = av.sfmData.SfMData()
+        if av.sfmDataIO.load(dataAV, inputSfm, av.sfmDataIO.ALL) and os.path.isdir(outDir):
+            views = dataAV.getViews()
+            for id, v in views.items():
+                inputFile = v.getImage().getImagePath()
+                if keepFilename:
+                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + ".exr")
+                    outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
+                else:
+                    outputFileMask = os.path.join(outDir, str(id) + ".exr")
+                    outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".exr")
+                paths[inputFile] = (outputFileMask, outputFileBoxes)
+
+        return paths
+
+    def processChunk(self, chunk):
+        import json
+        from segmentationRDS import image, segmentation
+        import numpy as np
+        import torch
+
+        try:
+            chunk.logManager.start(chunk.node.verboseLevel.value)
+
+            if not chunk.node.input:
+                chunk.logger.warning("Nothing to segment")
+                return
+            if not chunk.node.bboxFolder.value:
+                chunk.logger.warning("No folder containing bounded boxes")
+                return
+            if not chunk.node.output.value:
+                return
+
+            chunk.logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
+
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value)
+
+            if not os.path.exists(chunk.node.output.value):
+                os.mkdir(chunk.node.output.value)
+
+            processor = segmentation.BiRefNetSeg(PATH_TO_WEIGHT = chunk.node.segmentationModelPath.value,
+                                                 useGPU = chunk.node.useGpu.value)
+
+            bboxDict = {}
+            for file in os.listdir(chunk.node.bboxFolder.value):
+                if file.endswith(".json"):
+                    with open(os.path.join(chunk.node.bboxFolder.value,file)) as bboxFile:
+                        bb = json.load(bboxFile)
+                        bboxDict.update(bb)
+
+            for k, (iFile, oFile) in enumerate(outFiles.items()):
+                if k >= chunk.range.start and k <= chunk.range.last:
+                    img, h_ori, w_ori, PAR, orientation = image.loadImage(iFile, True)
+                    bboxes = np.asarray(bboxDict[iFile]["bboxes"])
+
+                    chunk.logger.info("image: {}".format(iFile))
+                    chunk.logger.debug("bboxes: {}".format(bboxDict[iFile]["bboxes"]))
+                    
+                    mask = processor.process(image = img,
+                                             bboxes = bboxes,
+                                             invert = chunk.node.maskInvert.value,
+                                             verbose = False)
+
+                    image.writeImage(oFile[0], mask, h_ori, w_ori, orientation, PAR)
+
+            del processor
+            torch.cuda.empty_cache()
+
+        finally:
+            chunk.logManager.end()
+
+    def stopProcess(sel, chunk):
+        # torch.cuda.empty_cache()
+        try:
+            del processor
+        except:
+            pass
+

--- a/meshroom/nodes/imageSegmentation/ImageBiRefNetSegBox.py
+++ b/meshroom/nodes/imageSegmentation/ImageBiRefNetSegBox.py
@@ -139,7 +139,6 @@ Based on the BiRefNet model.
 
             processor = segmentation.BiRefNetSeg(PATH_TO_WEIGHT = chunk.node.segmentationModelPath.value,
                                                  useGPU = chunk.node.useGpu.value)
-
             bboxDict = {}
             for file in os.listdir(chunk.node.bboxFolder.value):
                 if file.endswith(".json"):

--- a/meshroom/nodes/imageSegmentation/ImageSegmentationBox.py
+++ b/meshroom/nodes/imageSegmentation/ImageSegmentationBox.py
@@ -92,7 +92,7 @@ Based on the Segment Anything model.
         ),
     ]
 
-    def resolvedPaths(self, inputSfm, outDir, keepFilename):
+    def resolvedPaths(self, inputSfm, outDir, keepFilename, extension):
         import pyalicevision as av
         from pathlib import Path
 
@@ -103,11 +103,11 @@ Based on the Segment Anything model.
             for id, v in views.items():
                 inputFile = v.getImage().getImagePath()
                 if keepFilename:
-                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + ".exr")
+                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extension)
                     outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
                 else:
                     outputFileMask = os.path.join(outDir, str(id) + ".exr")
-                    outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".exr")
+                    outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + "." + extension)
                 paths[inputFile] = (outputFileMask, outputFileBoxes)
 
         return paths
@@ -132,7 +132,7 @@ Based on the Segment Anything model.
 
             chunk.logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
 
-            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value)
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extension.value)
 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)

--- a/meshroom/nodes/imageSegmentation/SegmentAnything.py
+++ b/meshroom/nodes/imageSegmentation/SegmentAnything.py
@@ -92,7 +92,7 @@ Based on the Segment Anything model.
         ),
     ]
 
-    def resolvedPaths(self, inputSfm, outDir, keepFilename):
+    def resolvedPaths(self, inputSfm, outDir, keepFilename, extension):
         import pyalicevision as av
         from pathlib import Path
 
@@ -103,11 +103,11 @@ Based on the Segment Anything model.
             for id, v in views.items():
                 inputFile = v.getImage().getImagePath()
                 if keepFilename:
-                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + ".exr")
+                    outputFileMask = os.path.join(outDir, Path(inputFile).stem + "." + extension)
                     outputFileBoxes = os.path.join(outDir, "bboxes_" + Path(inputFile).stem + ".jpg")
                 else:
-                    outputFileMask = os.path.join(outDir, str(id) + ".exr")
-                    outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".exr")
+                    outputFileMask = os.path.join(outDir, str(id) + "." + extension)
+                    outputFileBoxes = os.path.join(outDir, "bboxes_" + str(id) + ".jpg")
                 paths[inputFile] = (outputFileMask, outputFileBoxes)
 
         return paths
@@ -132,7 +132,7 @@ Based on the Segment Anything model.
 
             chunk.logger.info("Chunk range from {} to {}".format(chunk.range.start, chunk.range.last))
 
-            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value)
+            outFiles = self.resolvedPaths(chunk.node.input.value, chunk.node.output.value, chunk.node.keepFilename.value, chunk.node.extension.value)
 
             if not os.path.exists(chunk.node.output.value):
                 os.mkdir(chunk.node.output.value)

--- a/segmentationRDS/segmentation.py
+++ b/segmentationRDS/segmentation.py
@@ -424,10 +424,10 @@ class BiRefNetSeg:
         del self.brn
 
     def segment(self, image_uint8: np.ndarray, xyxy: np.ndarray) -> np.ndarray:
-        result_masks = []
         max_image_size = (2048, 4096)
         input_image_size = (image_uint8.shape[0], image_uint8.shape[1])
         matte_image = np.zeros(input_image_size)
+        result_masks = [matte_image[..., None]]
 
         for box in xyxy:
 

--- a/segmentationRDS/segmentation.py
+++ b/segmentationRDS/segmentation.py
@@ -441,7 +441,7 @@ class BiRefNetSeg:
             else:
                 resize_ratio = sqrt((max_image_size[0] * max_image_size[1])/(bboxSize[0] * bboxSize[1]))
                 resize = [(round(resize_ratio * imgDim - 1) // 32 + 1) * 32 for imgDim in bboxSize]
-                resize = (resize[1], resize[0])
+                resize = (resize[0], resize[1])
                 resizeTransf = torchvision.transforms.Resize(resize)
 
             transform_image = torchvision.transforms.Compose([

--- a/segmentationRDS/segmentation.py
+++ b/segmentationRDS/segmentation.py
@@ -3,6 +3,8 @@ import numpy as np
 import torch
 import torchvision
 
+from math import sqrt
+
 # Grounding DINO
 from groundingdino.util.inference import predict
 from groundingdino.models import build_model

--- a/segmentationRDS/segmentation.py
+++ b/segmentationRDS/segmentation.py
@@ -442,7 +442,7 @@ class BiRefNetSeg:
                 resize_ratio = sqrt((max_image_size[0] * max_image_size[1])/(bboxSize[0] * bboxSize[1]))
                 resize = [(round(resize_ratio * imgDim - 1) // 32 + 1) * 32 for imgDim in bboxSize]
                 resize = (resize[1], resize[0])
-                resizeTransf = torchvision.transforms.resize(resize)
+                resizeTransf = torchvision.transforms.Resize(resize)
 
             transform_image = torchvision.transforms.Compose([
                 torchvision.transforms.ToTensor(),


### PR DESCRIPTION
This PR adds a node dedicated to matting process using BiRefNet models.
Bounded boxes can be used as input to limit the process to a specific area in the frame.
If no bounded box is provided, the full image is processed.